### PR TITLE
fix: during cold start, log will appear below enter command

### DIFF
--- a/src/main/java/seedu/finbro/storage/Storage.java
+++ b/src/main/java/seedu/finbro/storage/Storage.java
@@ -206,7 +206,7 @@ public class Storage {
             }
 
             // All recovery attempts failed, return empty manager
-            logger.severe("All recovery attempts failed, starting with empty data");
+            System.out.println("All recovery attempts failed, starting with empty data");
             return new TransactionManager();
         }, new TransactionManager());  // Default value if locking fails
     }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -2,6 +2,7 @@ ____________________________________________________________
 Welcome to FinBro - Your Personal Finance Manager!
 Type 'help' to see available commands.
 ____________________________________________________________
+All recovery attempts failed, starting with empty data
 Enter command word:
 > ____________________________________________________________
 FinBro uses an interactive command experience. Type a command and follow the prompts.


### PR DESCRIPTION
This pull request includes changes to the logging mechanism in the `Storage` class and updates to the expected output for the text UI tests.

Logging mechanism update:

* [`src/main/java/seedu/finbro/storage/Storage.java`](diffhunk://#diff-ab7abd2171444be29564d11cc8829b436ea0dd530d06de8190286720a7d2d867L209-R209): Replaced the use of `logger.severe` with `System.out.println` for logging the message "All recovery attempts failed, starting with empty data".

Text UI test update:

* [`text-ui-test/EXPECTED.TXT`](diffhunk://#diff-8161fdd64ba5a246fb9cf6b8b5790e2a013e11782bc9aa0639849af43d42a9d3R5): Added the message "All recovery attempts failed, starting with empty data" to the expected output to match the new logging behavior.